### PR TITLE
Add bash version check to setup script

### DIFF
--- a/setup-bmad.sh
+++ b/setup-bmad.sh
@@ -5,6 +5,34 @@
 
 set -e  # Exit on error
 
+# Check bash version for associative array support
+check_bash_version() {
+    local bash_version
+    bash_version="${BASH_VERSION%%.*}"
+    
+    if [[ "$bash_version" -lt 4 ]]; then
+        echo -e "${RED}⚠️  Warning: Bash version $BASH_VERSION detected${NC}"
+        echo -e "${YELLOW}This script uses associative arrays which require Bash 4.0 or later.${NC}"
+        echo -e "${YELLOW}macOS ships with Bash 3.x by default.${NC}"
+        echo ""
+        echo -e "${CYAN}To fix this issue:${NC}"
+        echo "1. Install Homebrew if you haven't already:"
+        echo "   /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        echo ""
+        echo "2. Install modern bash:"
+        echo "   brew install bash"
+        echo ""
+        echo "3. Run this script with Homebrew's bash:"
+        echo "   /opt/homebrew/bin/bash $(basename "$0")"
+        echo ""
+        echo -e "${GRAY}Press Enter to continue anyway (may cause errors) or Ctrl+C to exit${NC}"
+        read -r
+    fi
+}
+
+# Run bash version check
+check_bash_version
+
 # Claude Code Theme Color Palette
 ORANGE='\033[38;2;244;132;95m'       # Claude orange #F4845F
 BRIGHT_ORANGE='\033[1;38;2;244;132;95m'  # Bright Claude orange


### PR DESCRIPTION
## Summary
Adds bash version compatibility check to the setup script to prevent issues with associative arrays on older bash versions.

## Changes
- Added `check_bash_version()` function that detects bash version
- Provides helpful error message and installation instructions for macOS users
- Allows script to continue with warning if user chooses to proceed
- Ensures compatibility with Bash 4.0+ requirement for associative arrays

## Test plan
- [x] Tested on Bash 3.x (shows warning and instructions)
- [x] Tested on Bash 4.0+ (continues normally)
- [x] Verified script functionality remains unchanged

## Notes
This addresses compatibility issues where the script would fail silently or with cryptic errors on macOS systems using the default Bash 3.x installation.